### PR TITLE
Fixed 'PF_DIR' is not defined error

### DIFF
--- a/postfixbuddy.py
+++ b/postfixbuddy.py
@@ -50,6 +50,7 @@ def get_options():
 
 # All variables defined in this script reply on finding the queue_directory.
 # This defines the PF_DIR variable which is called later on.
+PF_DIR = None
 try:
     GET_QUEUE_DIR = subprocess.Popen(['/usr/sbin/postconf',
                                       '-h', 'queue_directory'],


### PR DESCRIPTION
Fixes the following error when run on a device without postfix.
Before
```
Traceback (most recent call last):
  File "<stdin>", line 77, in <module>
NameError: name 'PF_DIR' is not defined
```
After:
```
Unable to find Postfix queue directory!
```