### PR TITLE
Changed PF_DIR declaration from None to empty string

### DIFF
--- a/postfixbuddy.py
+++ b/postfixbuddy.py
@@ -50,7 +50,7 @@ def get_options():
 
 # All variables defined in this script reply on finding the queue_directory.
 # This defines the PF_DIR variable which is called later on.
-PF_DIR = None
+PF_DIR = ""
 try:
     GET_QUEUE_DIR = subprocess.Popen(['/usr/sbin/postconf',
                                       '-h', 'queue_directory'],


### PR DESCRIPTION
Declaration of `PF_DIR` needs to be an empty string or we get the following error on a device without postfix:
```
Traceback (most recent call last):
  File "<stdin>", line 78, in <module>
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```
To clarify, the goal here is to allow `--help` option to run on a device where postfix isn't installed.
I can confirm this works now.
Graceful fail when postfix not installed:
```
$ ./postfixbuddy.py 
Unable to find Postfix queue directory!
```
Help function still runs:
```
$ ./postfixbuddy.py --help
usage: postfixbuddy.py [-h] [-l]
                       [-p {active,bounce,corrupt,deferred,hold,incoming}]
                       [-m DELETE_MAIL] [-c] [-H] [-r] [-f]
                       [-D DELETE_BY_SEARCH] [-s SHOW_MESSAGE] [-v]

optional arguments:
  -h, --help            show this help message and exit
  -l, --list            List all the current mail queues
  -p {active,bounce,corrupt,deferred,hold,incoming}, --purge {active,bounce,corrupt,deferred,hold,incoming}
                        Purge messages from specific queues.
  -m DELETE_MAIL, --message DELETE_MAIL
                        Delete specific email based on mailq ID.
  -c, --clean           Purge messages from all queues.
  -H, --hold            Hold all mail queues.
  -r, --release         Release all mail queues from held state.
  -f, --flush           Flush mail queues
  -D DELETE_BY_SEARCH, --delete DELETE_BY_SEARCH
                        Delete based on subject or email address
  -s SHOW_MESSAGE, --show SHOW_MESSAGE
                        Show message from queue ID
  -v, --version         Shows version information
```