### PR TITLE
Python3 Bytes conversion fix

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -62,7 +62,8 @@ disable=missing-docstring,
         pointless-statement,
         too-many-return-statements,
         unused-import,
-        unused-variable
+        unused-variable,
+        consider-using-with
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/postfixbuddy.py
+++ b/postfixbuddy.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# postfixbuddy.py created by Daniel Hand (daniel.hand@rackspace.co.uk)
+# postfixbuddy.py created by Daniel Hand (email@danielhand.io)
 # This is a recreation of pfHandle.perl but in Python.
 
 from __future__ import absolute_import, division, print_function
@@ -7,13 +7,13 @@ from __future__ import absolute_import, division, print_function
 # Standard Library
 import argparse
 import os
-from os.path import join
-import sys
 import subprocess
+import sys
+from os.path import join
 from subprocess import call
 
 
-__version__ = '0.2.0'
+__version__ = '0.3.0'
 
 
 def get_options():

--- a/postfixbuddy.py
+++ b/postfixbuddy.py
@@ -13,7 +13,7 @@ import subprocess
 from subprocess import call
 
 
-__version__ = '0.1.0'
+__version__ = '0.2.0'
 
 
 def get_options():

--- a/postfixbuddy.py
+++ b/postfixbuddy.py
@@ -50,6 +50,7 @@ def get_options():
 
 # All variables defined in this script reply on finding the queue_directory.
 # This defines the PF_DIR variable which is called later on.
+PF_DIR = None
 try:
     GET_QUEUE_DIR = subprocess.Popen(['/usr/sbin/postconf',
                                       '-h', 'queue_directory'],

--- a/postfixbuddy.py
+++ b/postfixbuddy.py
@@ -50,7 +50,7 @@ def get_options():
 
 # All variables defined in this script reply on finding the queue_directory.
 # This defines the PF_DIR variable which is called later on.
-PF_DIR = None
+PF_DIR = ''
 try:
     GET_QUEUE_DIR = subprocess.Popen(['/usr/sbin/postconf',
                                       '-h', 'queue_directory'],

--- a/postfixbuddy.py
+++ b/postfixbuddy.py
@@ -58,7 +58,7 @@ try:
                                      stderr=subprocess.PIPE)
     OUTPUT, ERROR = GET_QUEUE_DIR.communicate()
     if OUTPUT:
-        PF_DIR = OUTPUT.split()[0]
+        PF_DIR = OUTPUT.split()[0].decode('utf-8')
 except OSError:
     pass
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-pylint==1.8.1
-pycodestyle==2.5.0
-pytest==3.2.3
+pylint==2.9.3
+pycodestyle==2.7.0
+pytest==6.2.4
+isort==5.9.1


### PR DESCRIPTION
Fixes issue where bytes conversion in python3 broke the script;

Before:
~~~
root@Ubuntu2004:~# python3 ./postfixbuddy/postfixbuddy.py
Traceback (most recent call last):
  File "./postfixbuddy/postfixbuddy.py", line 79, in <module>
    ACTIVE_QUEUE = PF_DIR + '/active'
~~~

After:
~~~
root@Ubuntu2004:~# python3 ./postfixbuddy/postfixbuddy.py
==== Mail Queue Summary ====
Active Queue Count: 0
Bounce Queue Count: 0
Corrupt Queue Count: 0
Deferred Queue Count: 0
Hold Queue Count: 0
Incoming Queue Count: 0
~~~